### PR TITLE
disable scope debug data (https://docs.angularjs.org/guide/production)

### DIFF
--- a/demos/render-large-datasets-angularjs-reactjs/angular.htm
+++ b/demos/render-large-datasets-angularjs-reactjs/angular.htm
@@ -63,7 +63,18 @@
 
 
 		// I control the root of the application.
-		angular.module( "Demo" ).controller(
+		angular.module(
+			"Demo"
+			
+		).config(
+			function ($compileProvider) {
+
+				// disable debug data, https://docs.angularjs.org/guide/production
+				$compileProvider.debugInfoEnabled(false);
+
+			}
+
+		).controller(
 			"AppController",
 			function provideAppController( $scope ) {
 


### PR DESCRIPTION
Hi,

I have activated "production" mode in Angular -render-large-data-set.
See: https://docs.angularjs.org/guide/production

It's not a big deal, but it improves the performance. 
I think that it should be here at least to let know people that there is a "production mode" in Angular.

David