### PR TITLE
index.htm: Typo in meta tag

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-	<neta charset="utf-8" />
+	<meta charset="utf-8" />
 	<title>
 		JavaScript Demos
 	</title>


### PR DESCRIPTION
Corrected `neta` to `meta`. Just small typo :)